### PR TITLE
Fix SyntaxError with *args

### DIFF
--- a/pyetrade/market.py
+++ b/pyetrade/market.py
@@ -42,7 +42,7 @@ class ETradeMarket(object):
                                      self.resource_owner_secret,
                                      signature_type='AUTH_HEADER')
 
-    def get_quote(self, *args, dev=True, resp_format='json', detail_flag='ALL'):
+    def get_quote(self, dev=True, resp_format='json', detail_flag='ALL', *args):
         '''get_quote(dev, resp_format, **kwargs) -> resp
            param: dev
            type: bool


### PR DESCRIPTION
This commit fixes the following syntax error when importing market.py:

```
def get_quote(self, *args, dev=True, resp_format='json', detail_flag='ALL'):
                           ^
                           SyntaxError: invalid syntax
```