### PR TITLE
Add get transaction history

### DIFF
--- a/pyetrade/accounts.py
+++ b/pyetrade/accounts.py
@@ -403,22 +403,38 @@ class ETradeAccounts(object):
             #payload:           kwargs
             #
             uri = r'accounts/sandbox/rest'
-            api_url = '%s/%s/%s/transactions%s.%s' % (
-                    self.base_url_dev,
-                    uri,
-                    account_id,
-                    optional_uri,
-                    resp_format
-                )
+            if resp_format is 'json':
+                api_url = '%s/%s/%s/transactions%s.%s' % (
+                        self.base_url_dev,
+                        uri,
+                        account_id,
+                        optional_uri,
+                        resp_format
+                    )
+            elif resp_format is 'xml':
+                api_url = '%s/%s/%s/transactions%s' % (
+                        self.base_url_dev,
+                        uri,
+                        account_id,
+                        optional_uri
+                    )
         else:
             uri = r'accounts/rest'
-            api_url = '%s/%s/%s/transactions%s.%s' % (
-                    self.base_url_prod,
-                    uri,
-                    account_id,
-                    optional_uri,
-                    resp_format
-                )
+            if resp_format is 'json':
+                api_url = '%s/%s/%s/transactions%s.%s' % (
+                        self.base_url_prod,
+                        uri,
+                        account_id,
+                        optional_uri,
+                        resp_format
+                    )
+            elif resp_format is 'xml':
+                api_url = '%s/%s/%s/transactions%s' % (
+                        self.base_url_prod,
+                        uri,
+                        account_id,
+                        optional_uri
+                    )
 
         # Build Payload
         payload = kwargs
@@ -451,22 +467,38 @@ class ETradeAccounts(object):
         # Set Env
         if dev:
             uri = r'accounts/sandbox/rest'
-            api_url = '%s/%s/%s/transactions/%s.%s' % (
-                    self.base_url_dev,
-                    uri,
-                    account_id,
-                    transaction_id,
-                    resp_format
-                )
+            if resp_format is 'json':
+                api_url = '%s/%s/%s/transactions/%s.%s' % (
+                        self.base_url_dev,
+                        uri,
+                        account_id,
+                        transaction_id,
+                        resp_format
+                    )
+            elif resp_format is 'xml':
+                api_url = '%s/%s/%s/transactions/%s' % (
+                        self.base_url_dev,
+                        uri,
+                        account_id,
+                        transaction_id
+                    )
         else:
             uri = r'accounts/rest'
-            api_url = '%s/%s/%s/transactions/%s.%s' % (
-                    self.base_url_prod,
-                    uri,
-                    account_id,
-                    transaction_id,
-                    resp_format
-                )
+            if resp_format is 'json':
+                api_url = '%s/%s/%s/transactions/%s.%s' % (
+                        self.base_url_prod,
+                        uri,
+                        account_id,
+                        transaction_id,
+                        resp_format
+                    )
+            elif resp_format is 'xml':
+                api_url = '%s/%s/%s/transactions/%s' % (
+                        self.base_url_prod,
+                        uri,
+                        account_id,
+                        transaction_id
+                    )
 
         # Build Payload
         payload = kwargs

--- a/pyetrade/accounts.py
+++ b/pyetrade/accounts.py
@@ -391,10 +391,8 @@ class ETradeAccounts(object):
         if dev:
             #assemble the following:
             #self.base_url_dev: https://etws.etrade.com
-            #format string:     /
-            #uri:               accounts/rest
-            #format string:     /
-            #account_id:        {accountId}
+            #uri:               /accounts/rest
+            #account_id:        /{accountId}
             #format string:     /transactions
             # if not 'ALL' args:
             #   group:              /{Group}
@@ -404,8 +402,6 @@ class ETradeAccounts(object):
             #resp_format:       {.json}
             #payload:           kwargs
             #
-            #example:
-            #GET https://etwssandbox.etrade.com/accounts/sandbox/rest/83405188/transactions?count=10
             uri = r'accounts/sandbox/rest'
             api_url = '%s/%s/%s/transactions%s.%s' % (
                     self.base_url_dev,
@@ -452,8 +448,6 @@ class ETradeAccounts(object):
            required: true
            description: Numeric transaction ID'''
 
-        # example:
-        # https://etws.etrade.com/accounts/rest/{accountId}/transactions/{transactionId}
         # Set Env
         if dev:
             uri = r'accounts/sandbox/rest'

--- a/pyetrade/accounts.py
+++ b/pyetrade/accounts.py
@@ -60,7 +60,7 @@ class ETradeAccounts(object):
             return req.json()
         else:
             return req.text
-    
+
     def get_account_balance(self, account_id, dev=True, resp_format='json'):
         '''get_account_balance(dev, resp_format)
            param: account_id
@@ -163,7 +163,7 @@ class ETradeAccounts(object):
             return req.json()
         else:
             return req.text
-    
+
     def list_alerts(self, dev=True, resp_format='json'):
         '''list_alerts(dev, resp_format) -> resp
            param: dev
@@ -214,7 +214,7 @@ class ETradeAccounts(object):
             return req.json()
         else:
             return req.text
-    
+
     def read_alert(self, alert_id, dev=True, resp_format='json'):
         '''read_alert(alert_id, dev, resp_format) -> resp
            param: alert_id
@@ -272,7 +272,7 @@ class ETradeAccounts(object):
             return req.json()
         else:
             return req.text
-    
+
     def delete_alert(self, alert_id, dev=True, resp_format='json'):
         '''delete_alert(alert_id, dev, resp_format) -> resp
            param: alert_id
@@ -323,6 +323,79 @@ class ETradeAccounts(object):
 
         logger.debug(api_url)
         req = self.session.delete(api_url)
+        req.raise_for_status()
+        logger.debug(req.text)
+
+        if resp_format is 'json':
+            return req.json()
+        else:
+            return req.text
+
+    def get_transaction_history(self, account_id, dev=True,
+                    group = 'ALL',
+                    asset_type = 'ALL',
+                    transaction_type = 'ALL',
+                    ticker_symbol = 'ALL',
+                    resp_format='json', **kwargs):
+        '''get_transaction_history(account_id, dev, resp_format) -> resp
+           param: account_id
+           type: int
+           required: true
+           description: Numeric account ID
+           param: marker
+           type: str
+           description: Specify the desired starting point of the set
+                of items to return. Used for paging.
+           param: count
+           type: int
+           description: The number of orders to return in a response.
+                The default is 25. Used for paging.
+           rdescription: see ETrade API docs'''
+        # Set Env
+        if dev:
+            #assemble the following:
+            #self.base_url_dev: https://etws.etrade.com
+            #format string:     /
+            #uri:               accounts/rest
+            #format string:     /
+            #account_id:        {accountId}
+            #format string:     /transactions
+            # if not 'ALL' args:
+            #   group:              /{Group}
+            #   asset_type          /{AssetType}
+            #   transaction_type:   /{TransactionType}
+            #   ticker_symbol:      /{TickerSymbol}
+            #resp_format:       {.json}
+            #payload:           kwargs
+            #
+            #example:
+            #GET https://etwssandbox.etrade.com/accounts/sandbox/rest/83405188/transactions?count=10
+            uri = r'accounts/sandbox/rest'
+            optional_args = ''
+            api_url = '%s/%s/%s/transactions%s.%s' % (
+                    self.base_url_dev,
+                    uri,
+                    account_id,
+                    optional_args,
+                    resp_format
+                )
+        else:
+            uri = r'accounts/rest'
+            optional_args = ''
+            api_url = '%s/%s/%s/transactions%s.%s' % (
+                    self.base_url_prod,
+                    uri,
+                    account_id,
+                    optional_args,
+                    resp_format
+                )
+
+        # Build Payload
+        payload = kwargs
+        logger.debug('payload: %s', payload)
+
+        logger.debug(api_url)
+        req = self.session.get(api_url, params=payload)
         req.raise_for_status()
         logger.debug(req.text)
 

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -38,7 +38,7 @@ class TestETradeAccounts(unittest.TestCase):
         self.assertEqual(account.list_accounts(resp_format='xml'), r'<xml> returns </xml>')
         self.assertTrue(MockOAuthSession().get().json.called)
         self.assertTrue(MockOAuthSession().get.called)
-    
+
     # Mock out OAuth1Session
     @patch('pyetrade.accounts.OAuth1Session')
     def test_get_account_balance(self, MockOAuthSession):
@@ -112,7 +112,7 @@ class TestETradeAccounts(unittest.TestCase):
                 )
         self.assertTrue(MockOAuthSession().get().json.called)
         self.assertTrue(MockOAuthSession().get.called)
-    
+
     # Mock out OAuth1Session
     @patch('pyetrade.accounts.OAuth1Session')
     def test_list_alerts(self, MockOAuthSession):
@@ -229,3 +229,100 @@ class TestETradeAccounts(unittest.TestCase):
                 )
         self.assertTrue(MockOAuthSession().delete().json.called)
         self.assertTrue(MockOAuthSession().delete.called)
+
+    # Mock out OAuth1Session
+    @patch('pyetrade.accounts.OAuth1Session')
+    def test_get_transaction_history(self, MockOAuthSession):
+        '''test_get_transaction_history(MockOAuthSession) -> None
+           param: MockOAuthSession
+           type: mock.MagicMock
+           description: MagicMock object for OAuth1Sessions'''
+        # Set Mock returns
+        MockOAuthSession().get().json.return_value = "{'transaction': 'abc123'}"
+        MockOAuthSession().get().text = r'<xml> returns </xml>'
+        account = accounts.ETradeAccounts('abc123', 'xyz123', 'abctoken',
+                'xyzsecret')
+        # Test Dev JSON
+        self.assertEqual(account.get_transaction_history(12345),
+                "{'transaction': 'abc123'}")
+        # Test API URL
+        MockOAuthSession().get.assert_called_with(
+                ('https://etwssandbox.etrade.com/accounts/'
+                'sandbox/rest/12345/transactions.json'), params = {}
+                )
+        # Test Prod JSON
+        self.assertEqual(account.get_transaction_history(12345, dev=False),
+                "{'transaction': 'abc123'}")
+        # Test API URL
+        MockOAuthSession().get.assert_called_with(
+                ('https://etws.etrade.com/accounts/'
+                'rest/12345/transactions.json'), params = {}
+                )
+        # Test Dev XML
+        self.assertEqual(account.get_transaction_history(12345,
+                resp_format='xml'), r'<xml> returns </xml>')
+        # Test API URL
+        MockOAuthSession().get.assert_called_with(
+                ('https://etwssandbox.etrade.com/accounts/'
+                'sandbox/rest/12345/transactions'), params = {}
+                )
+        # Test Prod XML
+        self.assertEqual(account.get_transaction_history(12345,
+                dev=False, resp_format='xml'), r'<xml> returns </xml>')
+        # Test API URL
+        MockOAuthSession().get.assert_called_with(
+                ('https://etws.etrade.com/accounts/'
+                'rest/12345/transactions'), params = {}
+                )
+        # Test optional_args
+        self.assertEqual(account.get_transaction_history(12345,
+                group = 'WITHDRAWALS'), "{'transaction': 'abc123'}")
+
+        self.assertTrue(MockOAuthSession().get().json.called)
+        self.assertTrue(MockOAuthSession().get.called)
+
+    # Mock out OAuth1Session
+    @patch('pyetrade.accounts.OAuth1Session')
+    def test_get_transaction_details(self, MockOAuthSession):
+        '''test_get_transaction_details(MockOAuthSession) -> None
+           param: MockOAuthSession
+           type: mock.MagicMock
+           description: MagicMock object for OAuth1Sessions'''
+        # Set Mock returns
+        MockOAuthSession().get().json.return_value = "{'transaction': 'abc123'}"
+        MockOAuthSession().get().text = r'<xml> returns </xml>'
+        account = accounts.ETradeAccounts('abc123', 'xyz123', 'abctoken',
+                'xyzsecret')
+        # Test Dev JSON
+        self.assertEqual(account.get_transaction_details(12345, 67890),
+                "{'transaction': 'abc123'}")
+        # Test API URL
+        MockOAuthSession().get.assert_called_with(
+                ('https://etwssandbox.etrade.com/accounts/'
+                'sandbox/rest/12345/transactions/67890.json'), params = {}
+                )
+        # Test Prod JSON
+        self.assertEqual(account.get_transaction_details(12345, 67890,
+                dev=False), "{'transaction': 'abc123'}")
+        # Test API URL
+        MockOAuthSession().get.assert_called_with(
+                ('https://etws.etrade.com/accounts/'
+                'rest/12345/transactions/67890.json'), params = {}
+                )
+        # Test Dev XML
+        self.assertEqual(account.get_transaction_details(12345, 67890,
+                resp_format='xml'), r'<xml> returns </xml>')
+        MockOAuthSession().get.assert_called_with(
+                ('https://etwssandbox.etrade.com/accounts/'
+                'sandbox/rest/12345/transactions/67890'), params = {}
+                )
+        # Test Prod XML
+        self.assertEqual(account.get_transaction_details(12345, 67890,
+                dev=False, resp_format='xml'), r'<xml> returns </xml>')
+        MockOAuthSession().get.assert_called_with(
+                ('https://etws.etrade.com/accounts/'
+                'rest/12345/transactions/67890'), params = {}
+                )
+
+        self.assertTrue(MockOAuthSession().get().json.called)
+        self.assertTrue(MockOAuthSession().get.called)


### PR DESCRIPTION
added two new methods to accounts class: get_transaction_history and get_transaction_details
added test coverage for each
NOTE:  I am still waiting for production access, so the actual results of these have only been tested in the sandbox environment which retrieves some duplicate values when using optional arguments such as group = 'DEPOSITS'.  I will test in production environment soon and submit any bug fixes as necessary.