### PR TITLE
 add place_option_order()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,6 @@ install:
 dist:
 	python setup.py sdist
 clean:
+	$(RM) -fr .tox/
 	find . -iname *.pyc -exec rm -f {} +
 	pip uninstall -y pyetrade

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -249,4 +249,31 @@ Order Module
     # Lists orders of a account
     print(orders.list_orders(accountIDKey, resp_format='json'))
 
+    # place option order:
+    action = "BUY_OPEN"
+    symbol = "PLTR"
+    callPut = "PUT"
+    expiryDate = "2022-02-18"
+    strikePrice = 23
+    quantity = 1
+    limitPrice=1.97
+    orderTerm = "GOOD_UNTIL_CANCEL"  # "IMMEDIATE_OR_CANCEL"  # "GOOD_FOR_DAY"
+    marketSession = "REGULAR"
+    priceType = "LIMIT"
 
+    resp = order.place_option_order(
+          resp_format="xml",
+          accountId = account_id,
+          symbol = symbol,
+          callPut=callPut,
+          expiryDate=expiryDate,
+          strikePrice=strikePrice,
+          orderAction=action,
+          clientOrderId=clientOrderId,
+          priceType= priceType,
+          limitPrice=limitPrice,
+          allOrNone=False,
+          quantity=quantity,
+          orderTerm=orderTerm,
+          marketSession=marketSession,
+        )

--- a/pyetrade/order.py
+++ b/pyetrade/order.py
@@ -156,6 +156,23 @@ class ETradeOrder:
 
         return get_request_result(req, resp_format, [])
 
+    def find_option_orders(self, account_id, symbol, callPut, expiryDate, strikePrice):
+        """:description: Lists orders for a specific account ID Key
+        :return: List of matching option orders in an account
+        """
+        opt_sym = option_symbol(symbol, callPut, expiryDate, strikePrice)
+        results = []
+        orders = self.list_orders(account_id, resp_format="json", status="OPEN")  # this call may return empty
+        for o in orders["OrdersResponse"]["Order"]:
+            orderId = o["orderId"]
+            product = o["OrderDetail"][0]["Instrument"][0]["Product"]
+            symbol = product["symbol"]
+            if product["securityType"] == "OPTN":
+                symbol = product["productId"]["symbol"]  # e.g. "PLTR--220218P00023000"
+                if symbol == opt_sym:
+                    results.append(o)
+        return results
+
     def check_order(self, **kwargs):
         """:description: Check that required params for preview or place order are there and correct
 

--- a/pyetrade/order.py
+++ b/pyetrade/order.py
@@ -24,6 +24,23 @@ CALL = "Call"
 PUT  = "Put"
 
 
+# price: number
+# round_down: bool
+# return string
+def to_decimal_str(price, round_down):
+    spstr = "%.2f" % price  # round to 2-place decimal
+    spstrf = float(spstr)       # convert back to float again
+    diff = price - spstrf
+    if diff != 0:        # have to work hard to round to decimal
+      HALF_CENT = 0.005  # e.g. BUY  stop: round   up to decimal
+      if round_down:
+        HALF_CENT *= -1  # e.g. SELL stop: round down to decimal
+      price += HALF_CENT
+      if price > 0:
+        spstr = "%.2f" % price  # now round to 2-place decimal
+    return spstr
+
+
 # resp_format: xml (default) or json
 # empty_json: either [] or {}, depends on the caller's semantics
 def get_request_result(req, resp_format, empty_json):
@@ -239,16 +256,9 @@ class ETradeOrder:
         remove_invalid_price_from_kwargs("limitPrice")
         if "stopPrice" in kwargs:
           stopPrice = float(kwargs["stopPrice"])
-          spstr = "%.2f" % stopPrice  # round to 2-place decimal
-          spstrf = float(spstr)       # convert back to float again
-          diff = stopPrice - spstrf
-          if diff != 0:        # have to work hard to round to decimal
-            HALF_CENT = 0.005  #  BUY: round   up to decimal
-            if "SELL" == kwargs["orderAction"][:4]:
-              HALF_CENT *= -1  # SELL: round down to decimal
-            stopPrice += HALF_CENT
-            if stopPrice > 0:
-              spstr = "%.2f" % stopPrice  # now round to 2-place decimal
+          round_down = ("SELL" == kwargs["orderAction"][:4])
+          spstr = to_decimal_str(stopPrice, round_down)
+
           order["stopPrice"] = spstr
         payload = {
             order_type: {

--- a/pyetrade/order.py
+++ b/pyetrade/order.py
@@ -25,8 +25,8 @@ PUT  = "Put"
 
 
 # resp_format: xml (default) or json
-# empty_result: either [] or {}, depends on the caller's semantics
-def get_request_result(req, resp_format, empty_result):
+# empty_json: either [] or {}, depends on the caller's semantics
+def get_request_result(req, resp_format, empty_json):
     assert resp_format in ("json", "xml", None)  # TODO: why None?
 
     LOGGER.debug(req.text)
@@ -36,7 +36,7 @@ def get_request_result(req, resp_format, empty_result):
       if req.text.strip() == "":
         # otherwise, when ETrade server return empty string, we got this error:
         # simplejson.errors.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
-        return {}  # empty json object
+        return empty_json  # empty json object
       else:
         return req.json()
 

--- a/pyetrade/order.py
+++ b/pyetrade/order.py
@@ -64,14 +64,6 @@ def option_symbol(symbol, callPut, expiryDate, strikePrice):
   return opt_sym
 
 
-def _test_option_symbol():
-  expected = "PLTR--220218P00023000"
-  assert_equal(expected, option_symbol("PLTR", PUT, "2022-02-18",  23))
-  assert_equal(expected, option_symbol("PLTR", PUT, "2022-02-18",  23.00))
-  assert_equal(expected, option_symbol("PLTR", PUT, "2022-02-18", "23.0"))
-  return True  # if we reach here
-
-
 class OrderException(Exception):
     """:description: Exception raised when giving bad args to a method not from Etrade calls
 

--- a/pyetrade/order.py
+++ b/pyetrade/order.py
@@ -486,8 +486,16 @@ class ETradeOrder:
 
         return self.perform_request(self.session.post, resp_format, api_url, payload)
 
+    def place_changed_option_order(self, resp_format=None, **kwargs):
+        """:description: Places Option Order, only single leg CALL or PUT is supported for now
+           :return: Returns confirmation of the equity order
+        """
+        kwargs["securityType"] = "OPTN"
+        return self.place_changed_equity_order(resp_format, **kwargs)
+
     def place_changed_equity_order(self, resp_format=None, **kwargs):
         """:description: Places changes to equity orders
+            NOTE: the ETrade server will actually cancel the old orderId, and create a new orderId
 
            :param resp_format: Desired Response format, defaults to xml
            :type  resp_format: str, optional
@@ -520,7 +528,7 @@ class ETradeOrder:
                 "Got a successful preview with previewId: %s", kwargs["previewId"]
             )
 
-        api_url = self.base_url + "/" + kwargs["accountId"] + "/orders/"+kwargs["orderId"]+"change/place"
+        api_url = self.base_url + "/" + kwargs["accountId"] + "/orders/"+kwargs["orderId"]+"/change/place"
         # payload creation
         payload = self.build_order_payload("PlaceOrderRequest", **kwargs)
 

--- a/pyetrade/order.py
+++ b/pyetrade/order.py
@@ -523,6 +523,11 @@ class ETradeOrder:
             preview = self.preview_equity_order(resp_format, **kwargs)
             if resp_format == "xml":
                 preview = jxmlease.parse(preview)
+
+            if "Error" in preview:
+              print(str(preview))
+              raise Exception("Please check your order!")
+
             kwargs["previewId"] = preview["PreviewOrderResponse"]["PreviewIds"][
                 "previewId"
             ]

--- a/pyetrade/order.py
+++ b/pyetrade/order.py
@@ -13,7 +13,6 @@
 import dateutil.parser
 import logging
 import jxmlease
-from nose.tools import assert_equal
 from requests_oauthlib import OAuth1Session
 
 LOGGER = logging.getLogger(__name__)
@@ -70,13 +69,13 @@ def option_symbol(symbol, callPut, expiryDate, strikePrice):
 
   ed = dateutil.parser.parse(expiryDate)  # dateutil can handle most date formats
   edstr = ed.strftime("%y%m%d")
-  assert_equal(len(edstr), 6)
+  assert(len(edstr) == 6)
 
   sp = "%08d" % (float(strikePrice) * 1000)
-  assert_equal(len(sp), 8)
+  assert(len(sp) == 8)
 
   opt_sym = symstr + edstr + callPut.strip().upper()[0] + sp
-  assert_equal(len(opt_sym), 21)
+  assert(len(opt_sym) == 21)
   return opt_sym
 
 

--- a/pyetrade/order.py
+++ b/pyetrade/order.py
@@ -525,7 +525,7 @@ class ETradeOrder:
                 preview = jxmlease.parse(preview)
 
             if "Error" in preview:
-              print(str(preview))
+              LOGGER.error(preview)
               raise Exception("Please check your order!")
 
             kwargs["previewId"] = preview["PreviewOrderResponse"]["PreviewIds"][

--- a/pyetrade/order.py
+++ b/pyetrade/order.py
@@ -13,8 +13,7 @@
 import dateutil.parser
 import logging
 import jxmlease
-from nose.tools import *
-import pdb
+from nose.tools import assert_equal
 from requests_oauthlib import OAuth1Session
 
 LOGGER = logging.getLogger(__name__)

--- a/pyetrade/order.py
+++ b/pyetrade/order.py
@@ -14,6 +14,7 @@ import dateutil.parser
 import logging
 import jxmlease
 from nose.tools import *
+import pdb
 from requests_oauthlib import OAuth1Session
 
 LOGGER = logging.getLogger(__name__)
@@ -154,7 +155,7 @@ class ETradeOrder:
         LOGGER.debug(api_url)
         req = self.session.get(api_url, params=params, timeout=self.timeout)
 
-        return get_request_result(req, resp_format, [])
+        return get_request_result(req, resp_format, {})
 
     def find_option_orders(self, account_id, symbol, callPut, expiryDate, strikePrice):
         """:description: Lists orders for a specific account ID Key
@@ -163,14 +164,15 @@ class ETradeOrder:
         opt_sym = option_symbol(symbol, callPut, expiryDate, strikePrice)
         results = []
         orders = self.list_orders(account_id, resp_format="json", status="OPEN")  # this call may return empty
-        for o in orders["OrdersResponse"]["Order"]:
-            orderId = o["orderId"]
-            product = o["OrderDetail"][0]["Instrument"][0]["Product"]
-            symbol = product["symbol"]
-            if product["securityType"] == "OPTN":
-                symbol = product["productId"]["symbol"]  # e.g. "PLTR--220218P00023000"
-                if symbol == opt_sym:
-                    results.append(o)
+        if len(orders) > 0:
+            for o in orders["OrdersResponse"]["Order"]:
+                orderId = o["orderId"]
+                product = o["OrderDetail"][0]["Instrument"][0]["Product"]
+                symbol = product["symbol"]
+                if product["securityType"] == "OPTN":
+                    symbol = product["productId"]["symbol"]  # e.g. "PLTR--220218P00023000"
+                    if symbol == opt_sym:
+                        results.append(o)
         return results
 
     def check_order(self, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+python-dateutil
 requests
 requests_oauthlib
 xmltodict

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-nose
 python-dateutil
 requests
 requests_oauthlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+nose
 python-dateutil
 requests
 requests_oauthlib

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,5 +7,6 @@ Sphinx
 pytest
 pytest-cov
 pytest-mock
+python-dateutil
 tox
 bumpversion

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -8,13 +8,22 @@ import unittest
 from unittest.mock import patch
 from pyetrade import order
 from collections import OrderedDict
+from nose.tools import *
+
+
+def _test_option_symbol():
+  expected = "PLTR--220218P00023000"
+  assert_equal(expected, order.option_symbol("PLTR", order.PUT, "2022-02-18",  23))
+  assert_equal(expected, order.option_symbol("PLTR", order.PUT, "2022-02-18",  23.00))
+  assert_equal(expected, order.option_symbol("PLTR", order.PUT, "2022-02-18", "23.0"))
+  return True  # if we reach here
 
 
 class TestETradeOrder(unittest.TestCase):
     """TestEtradeOrder Unit Test"""
 
     def test_simple_funs(self):
-        self.assertTrue(order._test_option_symbol())
+        self.assertTrue(_test_option_symbol())
 
     @patch("pyetrade.order.OAuth1Session")
     def test_list_orders(self, MockOAuthSession):

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -13,6 +13,9 @@ from collections import OrderedDict
 class TestETradeOrder(unittest.TestCase):
     """TestEtradeOrder Unit Test"""
 
+    def test_simple_funs(self):
+        self.assertTrue(order._test_option_symbol())
+
     @patch("pyetrade.order.OAuth1Session")
     def test_list_orders(self, MockOAuthSession):
         """test_place_equity_order(MockOAuthSession) -> None

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -8,22 +8,16 @@ import unittest
 from unittest.mock import patch
 from pyetrade import order
 from collections import OrderedDict
-from nose.tools import *
-
-
-def _test_option_symbol():
-  expected = "PLTR--220218P00023000"
-  assert_equal(expected, order.option_symbol("PLTR", order.PUT, "2022-02-18",  23))
-  assert_equal(expected, order.option_symbol("PLTR", order.PUT, "2022-02-18",  23.00))
-  assert_equal(expected, order.option_symbol("PLTR", order.PUT, "2022-02-18", "23.0"))
-  return True  # if we reach here
 
 
 class TestETradeOrder(unittest.TestCase):
     """TestEtradeOrder Unit Test"""
 
-    def test_simple_funs(self):
-        self.assertTrue(_test_option_symbol())
+    def test_option_symbol(self):
+        expected = "PLTR--220218P00023000"
+        self.assertEqual(expected, order.option_symbol("PLTR", order.PUT, "2022-02-18",  23))
+        self.assertEqual(expected, order.option_symbol("PLTR", order.PUT, "2022-02-18",  23.00))
+        self.assertEqual(expected, order.option_symbol("PLTR", order.PUT, "2022-02-18", "23.0"))
 
     @patch("pyetrade.order.OAuth1Session")
     def test_list_orders(self, MockOAuthSession):


### PR DESCRIPTION
fix https://github.com/jessecooper/pyetrade/issues/13  for single CALL / PUT leg

add place_option_order()
add place_changed_option_order()

fix: https://github.com/jessecooper/pyetrade/issues/49
refactoring get_request_result(), 
