### PR TITLE
Fix parameter names in order module documentation examples

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -263,7 +263,7 @@ Order Module
 
     resp = order.place_option_order(
           resp_format="xml",
-          accountId = account_id,
+          accountIdKey = accountIDKey,
           symbol = symbol,
           callPut=callPut,
           expiryDate=expiryDate,

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -262,7 +262,7 @@ Order Module
     priceType = "LIMIT"
     clientOrderId = "ABC123456" # Unique alphanumeric identifier to prevent duplicate submissions of the same order
 
-    resp = order.place_option_order(
+    resp = orders.place_option_order(
           resp_format="xml",
           accountIdKey = accountIDKey,
           symbol = symbol,

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -260,6 +260,7 @@ Order Module
     orderTerm = "GOOD_UNTIL_CANCEL"  # "IMMEDIATE_OR_CANCEL"  # "GOOD_FOR_DAY"
     marketSession = "REGULAR"
     priceType = "LIMIT"
+    clientOrderId = "ABC123456" # Unique alphanumeric identifier to prevent duplicate submissions of the same order
 
     resp = order.place_option_order(
           resp_format="xml",


### PR DESCRIPTION
Correct the parameter name to `accountIdKey` and include the required `clientOrderId` in the documentation examples.

Ref: https://apisb.etrade.com/docs/api/order/api-order-v1.html#/definition/orderPlace