### PR TITLE
enable different response format #123

### DIFF
--- a/pyetrade/order.py
+++ b/pyetrade/order.py
@@ -554,7 +554,7 @@ class ETradeOrder(object):
         # payload creation
         payload = self.build_order_payload("PreviewOrderRequest", **kwargs)
 
-        return self.perform_request(self.session.post, api_url, payload, "xml")
+        return self.perform_request(self.session.post, api_url, payload, kwargs.get("resp_format", "xml"))
 
     def change_preview_equity_order(
         self, account_id_key: str, order_id: str, **kwargs
@@ -580,7 +580,7 @@ class ETradeOrder(object):
         # payload creation
         payload = self.build_order_payload("PreviewOrderRequest", **kwargs)
 
-        return self.perform_request(self.session.put, api_url, payload, "xml")
+        return self.perform_request(self.session.put, api_url, payload, kwargs.get("resp_format", "xml"))
 
     def place_option_order(self, **kwargs) -> dict:
         """:description: Places Option Order, only single leg CALL or PUT is supported for now
@@ -625,7 +625,7 @@ class ETradeOrder(object):
         # payload creation
         payload = self.build_order_payload("PlaceOrderRequest", **kwargs)
 
-        return self.perform_request(self.session.post, api_url, payload, "xml")
+        return self.perform_request(self.session.post, api_url, payload, kwargs.get("resp_format", "xml"))
 
     def place_changed_option_order(self, **kwargs) -> dict:
         """:description: Places Option Order, only single leg CALL or PUT is supported for now
@@ -675,7 +675,7 @@ class ETradeOrder(object):
         # payload creation
         payload = self.build_order_payload("PlaceOrderRequest", **kwargs)
 
-        return self.perform_request(self.session.put, api_url, payload, "xml")
+        return self.perform_request(self.session.put, api_url, payload, kwargs.get("resp_format", "xml"))
 
     def cancel_order(
         self, account_id_key: str, order_num: int, resp_format: str = "xml"

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -4,6 +4,7 @@
        * Test request error
        * Test API URL
 """
+import json
 import unittest
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -357,4 +358,127 @@ class TestETradeOrder(unittest.TestCase):
         self.assertTrue(MockOAuthSession().put.called)
         self.assertTrue(
             isinstance(orders.cancel_order("12345", 42, resp_format="xml"), dict)
+        )
+
+    @patch("pyetrade.order.OAuth1Session")
+    def test_preview_equity_order_resp_format_json(self, MockOAuthSession):
+        """Test that preview_equity_order forwards resp_format='json' to perform_request"""
+        json_response = {"PreviewOrderResponse": {"PreviewIds": {"previewId": "321"}}}
+        MockOAuthSession().post().json.return_value = json_response
+        MockOAuthSession().post().text = json.dumps(json_response)
+
+        orders = order.ETradeOrder(
+            "abc123", "xyz123", "abctoken", "xyzsecret", dev=False
+        )
+
+        result = orders.preview_equity_order(
+            accountIdKey="12345",
+            symbol="ABC",
+            orderAction="BUY",
+            clientOrderId="1a2b3c",
+            priceType="MARKET",
+            quantity=100,
+            orderTerm="GOOD_UNTIL_CANCEL",
+            marketSession="REGULAR",
+            resp_format="json",
+        )
+
+        self.assertEqual(result, json_response)
+        MockOAuthSession().post.assert_called_with(
+            "https://api.etrade.com/v1/accounts/12345/orders/preview",
+            json=unittest.mock.ANY,
+            timeout=30,
+        )
+
+    @patch("pyetrade.order.OAuth1Session")
+    def test_place_equity_order_resp_format_json(self, MockOAuthSession):
+        """Test that place_equity_order forwards resp_format='json' to perform_request"""
+        json_response = {"PlaceOrderResponse": {"OrderIds": {"orderId": "456"}}}
+        MockOAuthSession().post().json.return_value = json_response
+        MockOAuthSession().post().text = json.dumps(json_response)
+
+        orders = order.ETradeOrder(
+            "abc123", "xyz123", "abctoken", "xyzsecret", dev=False
+        )
+
+        result = orders.place_equity_order(
+            accountIdKey="12345",
+            symbol="ABC",
+            orderAction="BUY",
+            clientOrderId="1a2b3c",
+            priceType="MARKET",
+            quantity=100,
+            orderTerm="GOOD_UNTIL_CANCEL",
+            marketSession="REGULAR",
+            previewId="321",
+            resp_format="json",
+        )
+
+        self.assertEqual(result, json_response)
+        MockOAuthSession().post.assert_called_with(
+            "https://api.etrade.com/v1/accounts/12345/orders/place",
+            json=unittest.mock.ANY,
+            timeout=30,
+        )
+
+    @patch("pyetrade.order.OAuth1Session")
+    def test_place_option_order_resp_format_json(self, MockOAuthSession):
+        """Test that place_option_order forwards resp_format='json' to perform_request"""
+        json_response = {"PlaceOrderResponse": {"OrderIds": {"orderId": "789"}}}
+        MockOAuthSession().post().json.return_value = json_response
+        MockOAuthSession().post().text = json.dumps(json_response)
+
+        orders = order.ETradeOrder(
+            "abc123", "xyz123", "abctoken", "xyzsecret", dev=False
+        )
+
+        result = orders.place_option_order(
+            accountIdKey="12345",
+            symbol="AAPL",
+            orderAction="BUY_OPEN",
+            clientOrderId="opt1",
+            priceType="MARKET",
+            quantity=1,
+            orderTerm="GOOD_FOR_DAY",
+            marketSession="REGULAR",
+            securityType="OPTN",
+            callPut="CALL",
+            expiryDate="2022-02-18",
+            strikePrice=150,
+            previewId="321",
+            resp_format="json",
+        )
+
+        self.assertEqual(result, json_response)
+
+    @patch("pyetrade.order.OAuth1Session")
+    def test_place_changed_equity_order_resp_format_json(self, MockOAuthSession):
+        """Test that place_changed_equity_order forwards resp_format='json' to perform_request"""
+        json_response = {"PlaceOrderResponse": {"OrderIds": {"orderId": "999"}}}
+        MockOAuthSession().put().json.return_value = json_response
+        MockOAuthSession().put().text = json.dumps(json_response)
+
+        orders = order.ETradeOrder(
+            "abc123", "xyz123", "abctoken", "xyzsecret", dev=False
+        )
+
+        result = orders.place_changed_equity_order(
+            accountIdKey="12345",
+            orderId="111",
+            symbol="ABC",
+            orderAction="BUY",
+            clientOrderId="1a2b3c",
+            priceType="MARKET",
+            quantity=100,
+            orderTerm="GOOD_UNTIL_CANCEL",
+            marketSession="REGULAR",
+            previewId="321",
+            resp_format="json",
+        )
+
+        self.assertEqual(result, json_response)
+        MockOAuthSession().put.assert_called_with(
+            "https://api.etrade.com/v1/accounts/12345/orders/111/change/place",
+            json=unittest.mock.ANY,
+            timeout=30,
         )


### PR DESCRIPTION
 Summary

  - preview_equity_order, change_preview_equity_order, place_equity_order, and place_changed_equity_order hardcoded "xml" in their perform_request calls, ignoring the resp_format kwarg passed by
  the caller
  - Replaced the hardcoded "xml" with kwargs.get("resp_format", "xml") so the parameter is properly forwarded
  - place_option_order and place_changed_option_order also inherit the fix since they delegate via **kwargs

  Test plan

  - Added 4 new tests that call each fixed method with resp_format="json", mock the session to return JSON, and assert the response is parsed as JSON (not piped through xmltodict)
  - All 11 tests pass
